### PR TITLE
Add Proxy User Support

### DIFF
--- a/images/hadoop-testing-base/Dockerfile
+++ b/images/hadoop-testing-base/Dockerfile
@@ -65,7 +65,11 @@ COPY ./files /
 # Configure and setup hadoop
 RUN /root/setup-hadoop.sh
 
-ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.171-8.b10.el7_5.x86_64/jre/
+# Create a few more accounts to test proxyuser support
+RUN useradd -m alice
+RUN useradd -m bob
+
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
 ENV LIBHDFS3_CONF /etc/hadoop/conf/hdfs-site.xml
 ENV HADOOP_CONF_DIR /etc/hadoop/conf
 ENV HADOOP_HOME /usr/lib/hadoop

--- a/images/hadoop-testing-base/files/etc/hadoop/conf.test/core-site.xml
+++ b/images/hadoop-testing-base/files/etc/hadoop/conf.test/core-site.xml
@@ -21,6 +21,16 @@
     </property>
 
     <property>
+        <name>hadoop.proxyuser.testuser.hosts</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.testuser.users</name>
+        <value>alice</value>
+    </property>
+
+    <property>
         <name>hadoop.security.authentication</name>
         <value>simple</value>
     </property>

--- a/images/hadoop-testing-base/files/root/init-hdfs.sh
+++ b/images/hadoop-testing-base/files/root/init-hdfs.sh
@@ -44,7 +44,11 @@ hdfs dfs -mkdir -p /tmp \
 && hdfs dfs -chmod -R 1777 /user/history \
 && hdfs dfs -chown mapred:hadoop /user/history \
 && hdfs dfs -mkdir -p /user/testuser \
-&& hdfs dfs -chown testuser /user/testuser
+&& hdfs dfs -chown testuser /user/testuser \
+&& hdfs dfs -mkdir -p /user/alice \
+&& hdfs dfs -chown alice /user/alice \
+&& hdfs dfs -mkdir -p /user/bob \
+&& hdfs dfs -chown bob /user/bob
 
 exit_code=$?
 if [[ $exit_code != 0 ]]; then

--- a/images/hadoop-testing-kerberos/files/etc/hadoop/conf.test/core-site.xml
+++ b/images/hadoop-testing-kerberos/files/etc/hadoop/conf.test/core-site.xml
@@ -21,6 +21,16 @@
     </property>
 
     <property>
+        <name>hadoop.proxyuser.testuser.hosts</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.testuser.users</name>
+        <value>alice</value>
+    </property>
+
+    <property>
         <name>hadoop.security.authentication</name>
         <value>kerberos</value>
     </property>

--- a/images/hadoop-testing-kerberos/files/root/setup-kerb.sh
+++ b/images/hadoop-testing-kerberos/files/root/setup-kerb.sh
@@ -24,5 +24,7 @@ kdb5_util create -s -P testpass \
 && create_keytabs worker \
 && kadmin.local -q "addprinc -pw adminpass admin/admin" \
 && kadmin.local -q "addprinc -pw testpass testuser" \
+&& kadmin.local -q "addprinc -pw testpass alice" \
+&& kadmin.local -q "addprinc -pw testpass bob" \
 && kadmin.local -q "xst -norandkey -k /home/testuser/testuser.keytab testuser" \
 && chown testuser:testuser /home/testuser/testuser.keytab


### PR DESCRIPTION
Adds 2 new users:
- alice
- bob

And adds support for the existing user "testuser" to proxy as "alice" (but not "bob").

This makes it possible to test user impersonation support in applications.