### PR TITLE
Remove unused ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 htmlcov/
 .pytest_cache/
 hadoop_test_cluster/krb5.conf
+__pycache__/

--- a/hadoop_test_cluster/docker-compose.yaml
+++ b/hadoop_test_cluster/docker-compose.yaml
@@ -19,8 +19,6 @@ services:
       - 9000:9000    # NN
       - 50070:50070  # NN webui
       - 8088:8088    # RM webui
-      - 88:88/udp    # Kerberos
-      - 749:749      # Kerberos
     tmpfs:
       - /tmp:noexec
 


### PR DESCRIPTION
Some docker installs apparently have issues with privileged ports.
These were unused, so easier to just remove.

https://github.com/docker/for-mac/issues/3464