### PR TITLE
Start MapReduce History Server

### DIFF
--- a/hadoop_test_cluster/docker-compose.yaml
+++ b/hadoop_test_cluster/docker-compose.yaml
@@ -19,6 +19,8 @@ services:
       - 9000:9000    # NN
       - 50070:50070  # NN webui
       - 8088:8088    # RM webui
+      - 10020:10020  # MR History
+      - 19888:19888  # MR History webui
     tmpfs:
       - /tmp:noexec
 

--- a/images/hadoop-testing/files/etc/master.supervisord.d/mapred-historyserver.conf
+++ b/images/hadoop-testing/files/etc/master.supervisord.d/mapred-historyserver.conf
@@ -1,0 +1,9 @@
+[program:mapred-historyserver]
+command=mapred historyserver
+startsecs=2
+stopwaitsecs=10
+user=mapred
+redirect_stderr=true
+stdout_logfile=/var/log/mapred-historyserver/mapred-historyserver.log
+autostart=true
+autorestart=false


### PR DESCRIPTION
This PR starts the MapReduce History Server and open ports on master

It should fix tests in this PR in skein https://github.com/jcrist/skein/pull/197

As htcluster command seems to pull docker image. I didn't know how to simply retest with the docker image built from source. So I did the test by starting by hand the MR history server (using `htcluster -u root -s master exec -- mapred historyserver`)